### PR TITLE
Avoid integer overflow in xh_vm_map_gpa()

### DIFF
--- a/src/vmm/vmm_api.c
+++ b/src/vmm/vmm_api.c
@@ -204,13 +204,13 @@ xh_vm_map_gpa(uint64_t gpa, size_t len)
 {
 	assert(mmap_style == VM_MMAP_ALL);
 
-	if ((gpa < lowmem) && ((gpa + len) <= lowmem)) {
+	if ((gpa < lowmem) && (len <= lowmem) && ((gpa + len) <= lowmem)) {
 		return ((void *) (((uintptr_t) lowmem_addr) + gpa));
 	}
 
 	if (gpa >= (4ull << 30)) {
 		gpa -= (4ull << 30);
-		if ((gpa < highmem) && ((gpa + len) <= highmem)) {
+		if ((gpa < highmem) && (len <= highmem) && ((gpa + len) <= highmem)) {
 			return ((void *) (((uintptr_t) highmem_addr) + gpa));
 		}
 	}


### PR DESCRIPTION
This is related to FreeBSD-SA-16:38.bhyve[0] AKA CVE-2016-1889 which was
discovered by Felix Wilhelm. In the context of hyperkit the code in
question runs as an unprivileged user.

Thanks to Gleb Smirnoff and the FreeBSD security team for advanced
notice on this issue.

[0] https://lists.freebsd.org/pipermail/freebsd-announce/2016-December/001773.html