### PR TITLE
Make PCI interupts allocation static when using bootrom (UEFI).

### DIFF
--- a/include/xhyve/firmware/bootrom.h
+++ b/include/xhyve/firmware/bootrom.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+const char *bootrom(void);
 void bootrom_init(const char *bootrom_path);
 uint64_t bootrom_load(void);
 bool bootrom_contains_gpa(uint64_t gpa);

--- a/include/xhyve/ioapic.h
+++ b/include/xhyve/ioapic.h
@@ -29,8 +29,10 @@
 
 #pragma once
 
+struct pci_devinst;
+
 /*
  * Allocate a PCI IRQ from the I/O APIC.
  */
 void ioapic_init(void);
-int ioapic_pci_alloc_irq(void);
+int ioapic_pci_alloc_irq(struct pci_devinst *pi);

--- a/include/xhyve/pci_irq.h
+++ b/include/xhyve/pci_irq.h
@@ -36,7 +36,8 @@ void pci_irq_deassert(struct pci_devinst *pi);
 void pci_irq_init(void);
 void pci_irq_reserve(int irq);
 void pci_irq_use(int irq);
-int pirq_alloc_pin(void);
+int pirq_alloc_pin(struct pci_devinst *pi);
+
 int pirq_irq(int pin);
 uint8_t pirq_read(int pin);
 void pirq_write(int pin, uint8_t val);

--- a/src/firmware/bootrom.c
+++ b/src/firmware/bootrom.c
@@ -48,13 +48,20 @@
 static const char *romfile;
 static uint64_t bootrom_gpa = (1ULL << 32);
 
+const char *
+bootrom(void)
+{
+    return (romfile);
+}
+
 void
 bootrom_init(const char *romfile_path)
 {
     romfile = romfile_path;
 }
 
-uint64_t bootrom_load(void)
+uint64_t
+bootrom_load(void)
 {
 
     struct stat sbuf;

--- a/src/ioapic.c
+++ b/src/ioapic.c
@@ -27,6 +27,8 @@
  */
 
 #include <xhyve/vmm/vmm_api.h>
+#include <xhyve/firmware/bootrom.h>
+#include <xhyve/pci_emul.h>
 #include <xhyve/ioapic.h>
 
 /*
@@ -58,11 +60,15 @@ ioapic_init(void)
 }
 
 int
-ioapic_pci_alloc_irq(void)
+ioapic_pci_alloc_irq(struct pci_devinst *pi)
 {
 	static int last_pin;
 
 	if (pci_pins == 0)
 		return (-1);
+        if (bootrom()) {
+                /* For external bootrom use fixed mapping. */
+                return (16 + (4 + pi->pi_slot + pi->pi_lintr.pin) % 8);
+        }
 	return (16 + (last_pin++ % pci_pins));
 }

--- a/src/pci_emul.c
+++ b/src/pci_emul.c
@@ -1542,7 +1542,7 @@ pci_lintr_route(struct pci_devinst *pi)
 	 * is not yet assigned.
 	 */
 	if (ii->ii_ioapic_irq == 0)
-		ii->ii_ioapic_irq = ioapic_pci_alloc_irq();
+		ii->ii_ioapic_irq = ioapic_pci_alloc_irq(pi);
 	assert(ii->ii_ioapic_irq > 0);
 
 	/*
@@ -1550,7 +1550,7 @@ pci_lintr_route(struct pci_devinst *pi)
 	 * not yet assigned.
 	 */
 	if (ii->ii_pirq_pin == 0)
-		ii->ii_pirq_pin = pirq_alloc_pin();
+		ii->ii_pirq_pin = pirq_alloc_pin(pi);
 	assert(ii->ii_pirq_pin > 0);
 
 	pi->pi_lintr.ioapic_irq = ii->ii_ioapic_irq;


### PR DESCRIPTION
This makes factual interrupt routing match one shipped with UEFI
firmware.  With old firmware this make legacy interrupts work reliable
for functions 0 of PCI slots 3-6.  Updated UEFI image fixes problem
completely.